### PR TITLE
Update setHeader example

### DIFF
--- a/doc/response.md
+++ b/doc/response.md
@@ -3,7 +3,7 @@
 ### Methods
 >  Adding headers
 ```php
-$response->setHeader(['Content-Type', 'application/json');
+$response->setHeader(['Content-Type' => 'application/json']);
 ```
 
 > Set status code header.
@@ -15,7 +15,7 @@ $response->setStatusCode('200 OK');
 
 > execute all header.
 ```php
-$response->setHeader(['Content-Type', 'application/json')->reponse();
+$response->setHeader(['Content-Type' => 'application/json'])->reponse();
 ```
 
 > Return a response in json format. This method set Content-Type to application/json automatically.


### PR DESCRIPTION
At the moment the example of **adding headers** in **response.md** is `$response->setHeader(['Content-Type', 'application/json');`, but this will attach the Header as an Array.

After seeing the Response Class, the correct way of adding headers is using as associative array: `$response->setHeader(['Content-Type' => 'application/json']);`